### PR TITLE
added race results to account

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -18,16 +18,48 @@ class AccountController extends Controller
         if (!$user) {
             return back()->with('error', 'Пожалуйста, зарегестрируйтесь или залогиньтесь!');
         }
-        //почему-то не работает eloquent, разобраться
-        // $races = User::find($user->id)->races();
-        $races = Race::select(['races.*'])
-            ->join('registrations_for_race', 'race_id', '=', 'races.id')
-            ->where('user_id', '=', $user->id)
-            ->get();
 
         return view('user.account', [
+            'user' => $user
+        ]);
+    }
+
+    public function showActiveRaces()
+    {
+        $user = Auth::user();
+        if (!$user) {
+            return back()->with('error', 'Пожалуйста, зарегестрируйтесь или залогиньтесь!');
+        }
+        //почему-то не работает eloquent, разобраться
+        // $races = User::find($user->id)->races();
+        $activeRaces = Race::select(['races.*'])
+            ->join('registrations_for_race', 'race_id', '=', 'races.id')
+            ->where('user_id', '=', $user->id)
+            ->where('status_of_race_id', 1)
+            ->get();
+
+        return view('user.activeRaces', [
             'user' => $user,
-            'races' => $races,
+            'races' => $activeRaces,
+        ]);
+    }
+
+    public function showFinishedRaces()
+    {
+        $user = Auth::user();
+        if (!$user) {
+            return back()->with('error', 'Пожалуйста, зарегестрируйтесь или залогиньтесь!');
+        }
+
+        $finishedRaces = Race::select(['races.*', 'registrations_for_race.*'])
+            ->join('registrations_for_race', 'race_id', '=', 'races.id')
+            ->where('user_id', '=', $user->id)
+            ->where('status_of_race_id', 3)
+            ->get();
+
+        return view('user.finishedRaces', [
+            'user' => $user,
+            'races' => $finishedRaces,
         ]);
     }
 

--- a/database/migrations/2021_09_12_234055_create_registrations_for_race_table.php
+++ b/database/migrations/2021_09_12_234055_create_registrations_for_race_table.php
@@ -18,7 +18,7 @@ class CreateRegistrationsForRaceTable extends Migration
                 ->constrained('races');
             $table->foreignId('user_id')
                 ->constrained('users');
-            $table->integer('finish_time')
+            $table->time('finish_time')
                 ->nullable();
             $table->integer('place')
                 ->nullable();

--- a/resources/views/user/activeRaces.blade.php
+++ b/resources/views/user/activeRaces.blade.php
@@ -13,7 +13,6 @@
 </head>
 
 <body>
-
     <div class="container mt-5">
         <nav class="nav">
             <a href="{{ route('index') }}"><i class="nav__logo fas fa-running"></i></a>
@@ -67,6 +66,34 @@
                         </a>
                     </nav>
                 </div>
+            </div>
+            <div class="col-lg-8 pb-5">
+                <div>
+                    <h3 class="feed__title">МОИ ТЕКУЩИЕ ЗАБЕГИ</h3>
+                </div><br>
+                @if(session()->has('success'))
+                <div>{{ session()->get('success') }}</div><br>
+                @endif
+
+                @if(session()->has('error'))
+                <div>{{ session()->get('error') }}</div>
+                @endif
+
+                @forelse($races as $race)
+                <div>
+                    <div>
+                        <h4><i>{{ $race->title }}</i></h4>
+                    </div>
+                    <div>{{ $race->date }}</div>
+                    <div>{{ $race->distance }} км</div>
+                    <div><a href="{{ route('races.show', ['race' => $race]) }}">Подробнее...</a></div>
+                    <div><a href="{{ route( 'unsubscribe', ['race_id' => $race->id]) }}" class="delete" rel="">Отменить</a></div>
+                </div><br><br>
+                @empty
+                <br><br><br>
+                <div>У вас пока что нет ни одной регистрации на забег!</div>
+                <div><a href="{{ route('index')}}">Записаться на мой первый забег</a></div>
+                @endforelse
             </div>
         </div>
     </div>

--- a/resources/views/user/finishedRaces.blade.php
+++ b/resources/views/user/finishedRaces.blade.php
@@ -13,7 +13,6 @@
 </head>
 
 <body>
-
     <div class="container mt-5">
         <nav class="nav">
             <a href="{{ route('index') }}"><i class="nav__logo fas fa-running"></i></a>
@@ -67,6 +66,36 @@
                         </a>
                     </nav>
                 </div>
+            </div>
+            <div class="col-lg-8 pb-5">
+                <div>
+                    <h3 class="feed__title">МОИ ПРОШЕДШИЕ ЗАБЕГИ</h3>
+                </div><br>
+                @if(session()->has('success'))
+                <div>{{ session()->get('success') }}</div><br>
+                @endif
+
+                @if(session()->has('error'))
+                <div>{{ session()->get('error') }}</div>
+                @endif
+
+                @forelse($races as $race)
+                <div>
+                    <div>
+                        <h4><i>{{ $race->title }}</i></h4>
+                    </div>
+                    <div>{{ $race->date }}</div>
+                    <div>{{ $race->distance }} км</div>
+                    <div>Твое время: {{$race->finish_time}}</div>
+                    <div>Твое место: {{$race->place}}</div>
+                    <div><a href="{{ route('races.show', ['race' => $race]) }}">Подробне...</a></div>
+                    <div><a href="{{ route( 'unsubscribe', ['race_id' => $race->id]) }}" class="delete" rel="">Отменить</a></div>
+                </div><br><br>
+                @empty
+                <br><br><br>
+                <div>У вас пока что нет ни одной регистрации на забег!</div>
+                <div><a href="{{ route('index')}}">Записаться на мой первый забег</a></div>
+                @endforelse
             </div>
         </div>
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,14 +16,14 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
+// RACE //
 Route::resource('races', RaceController::class)
     ->except(['edit', 'update', 'destroy']);
-
-Route::get('/', [RaceController::class, 'index'])->name('index');
 
 Route::get('/', [RaceController::class, 'index'])
     ->name('index');
 
+// AUTH //
 Route::get('/logout', function () {
     return view('auth.logout');
 })->name('logout');
@@ -36,10 +36,24 @@ Route::get('/register', function() {
     return view('auth.register');
 })->name('register');
 
-Route::get('/account', [AccountController::class, 'index'])->name('account');
+// ACCOUNT //
+Route::get('/account', [AccountController::class, 'index'])
+    ->name('account');
 
-Route::get('/subscribe/{id}', [AccountController::class, 'subscribe'])->where('id', '\d+')->name('subscribe');
-Route::get('/account/unsubscribe/{race_id}', [AccountController::class, 'unsubscribe'])->where('id', '\d+')->name('unsubscribe');
+Route::get('/account/active', [AccountController::class, 'showActiveRaces'])
+    ->name('account.active');
 
+Route::get('/account/finished', [AccountController::class, 'showFinishedRaces'])
+    ->name('account.finished');
+
+Route::get('/subscribe/{id}', [AccountController::class, 'subscribe'])
+    ->where('id', '\d+')
+    ->name('subscribe');
+
+Route::get('/account/unsubscribe/{race_id}', [AccountController::class, 'unsubscribe'])
+    ->where('id', '\d+')
+    ->name('unsubscribe');
+
+// SEARCH //
 Route::get('/search', [RaceController::class, 'search'])
     ->name('search');


### PR DESCRIPTION
- account index now shows only menu for navigation within account
- added two separate routes for active and finished races
- added two functions in AccountController for getting races from DB
- finishedRaces view now displays results from race // _status_of_race_id and race results have to be entered manually in DB_
- races are filtered according to status_of_race_id
- fixed registration_for_race migration. finish_time column in now TIME type instead of INTEGER
- removed unnecessary HTML code in account.blade